### PR TITLE
[ENH] demo activity with all input types and widgets

### DIFF
--- a/activities/AllWidgetsDemo/all_widgets_schema
+++ b/activities/AllWidgetsDemo/all_widgets_schema
@@ -1,0 +1,90 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc1/contexts/generic",
+    "@type": "reproschema:Activity",
+    "@id": "all_widgets_schema",
+    "prefLabel": "demo of all input types and widgets",
+    "description": "dummy activity to show all inputs types and widgets",
+    "schemaVersion": "1.0.0-rc1",
+    "version": "0.0.1",
+    "ui": {
+        "addProperties": [
+                {"isAbout": "items/radio_item",
+                "variableName": "radio_item",
+                "isVis": true
+                },
+                {"isAbout": "items/radio_item_multiple_choice",
+                "variableName": "radio_item_multiple_choice",
+                "isVis": true
+                },
+                {"isAbout": "items/select_item",
+                "variableName": "select_item",
+                "isVis": true
+                },
+                {"isAbout": "items/select_item_multiple_choice",
+                "variableName": "select_item_multiple_choice",
+                "isVis": true
+                },
+                {"isAbout": "items/slider_item",
+                "variableName": "slider_item",
+                "isVis": true
+                },
+                {"isAbout": "items/integer_item",
+                "variableName": "integer_item",
+                "isVis": true
+                },
+                {"isAbout": "items/time_range_item",
+                "variableName": "time_range_item",
+                "isVis": true
+                },
+                {"isAbout": "items/text_item",
+                "variableName": "text_item",
+                "isVis": true
+                },
+                {"isAbout": "items/email_item",
+                "variableName": "email_item",
+                "isVis": true
+                },
+                {"isAbout": "items/multitext_item",
+                "variableName": "multitext_item",
+                "isVis": true
+                },
+                {"isAbout": "items/language_item",
+                "variableName": "language_item",
+                "isVis": true
+                },
+                {"isAbout": "items/date_item",
+                "variableName": "date_item",
+                "isVis": true
+                },
+                {"isAbout": "items/participant_id_item",
+                "variableName": "participant_id_item",
+                "isVis": true
+                },
+                {"isAbout": "items/float_item",
+                "variableName": "float_item",
+                "isVis": true
+                }
+        ],
+        "order": [
+            "items/radio_item",
+            "items/radio_item_multiple_choice",
+            "items/select_item",
+            "items/select_item_multiple_choice",
+            "items/slider_item",
+            "items/integer_item",
+            "items/time_range_item",
+            "items/text_item",
+            "items/email_item",
+            "items/multitext_item",
+            "items/language_item",
+            "items/date_item",
+            "items/float_item",
+            "items/participant_id_item"
+        ],
+        "shuffle": false,
+        "allow": [
+			"reproschema:AutoAdvance",
+			"reproschema:AllowExport"
+		]
+    }
+}

--- a/activities/AllWidgetsDemo/all_widgets_schema
+++ b/activities/AllWidgetsDemo/all_widgets_schema
@@ -63,6 +63,42 @@
                 {"isAbout": "items/float_item",
                 "variableName": "float_item",
                 "isVis": true
+                },
+                {"isAbout": "items/year_item",
+                "variableName": "year_item",
+                "isVis": true
+                },
+                {"isAbout": "items/country_item",
+                "variableName": "country_item",
+                "isVis": true
+                },
+                {"isAbout": "items/state_item",
+                "variableName": "state_item",
+                "isVis": true
+                },
+                {"isAbout": "items/sign_item",
+                "variableName": "sign_item",
+                "isVis": true
+                },
+                {"isAbout": "items/save_item",
+                "variableName": "save_item",
+                "isVis": true
+                },
+                {"isAbout": "items/document_upload_item",
+                "variableName": "document_upload_item",
+                "isVis": true
+                },
+                {"isAbout": "items/read_only_item",
+                "variableName": "read_only_item",
+                "isVis": true
+                },
+                {"isAbout": "items/static_item",
+                "variableName": "static_item",
+                "isVis": true
+                },
+                {"isAbout": "items/audio_check_item",
+                "variableName": "audio_check_item",
+                "isVis": true
                 }
         ],
         "order": [
@@ -70,16 +106,26 @@
             "items/radio_item_multiple_choice",
             "items/select_item",
             "items/select_item_multiple_choice",
-            "items/slider_item",
+            "items/country_item",
+            "items/language_item",
+            "items/state_item",
             "items/integer_item",
+            "items/year_item",
+            "items/date_item",
             "items/time_range_item",
             "items/text_item",
-            "items/email_item",
             "items/multitext_item",
-            "items/language_item",
-            "items/date_item",
+            "items/email_item",
+            "items/participant_id_item",
+            "items/sign_item",
+            "items/document_upload_item",
+            "items/save_item",
+            "items/read_only_item",
+            "items/static_item",
+            "items/audio_check_item",
             "items/float_item",
-            "items/participant_id_item"
+            "items/slider_item"
+            
         ],
         "shuffle": false,
         "allow": [

--- a/activities/AllWidgetsDemo/all_widgets_schema
+++ b/activities/AllWidgetsDemo/all_widgets_schema
@@ -112,7 +112,12 @@
                 {"isAbout": "items/audio_image_record_item",
                 "variableName": "audio_image_record_item",
                 "isVis": true
+                },
+                {"isAbout": "items/audio_number_record_item",
+                "variableName": "audio_number_record_item",
+                "isVis": true
                 }
+                
         ],
         "order": [
             "items/radio_item",
@@ -140,7 +145,8 @@
             "items/static_item",
             "items/float_item",
             "items/slider_item",
-            "items/read_only_item"
+            "items/read_only_item",
+            "items/audio_number_record_item"
         ],
         "shuffle": false,
         "allow": [

--- a/activities/AllWidgetsDemo/all_widgets_schema
+++ b/activities/AllWidgetsDemo/all_widgets_schema
@@ -4,6 +4,7 @@
     "@id": "all_widgets_schema",
     "prefLabel": "demo of all input types and widgets",
     "description": "dummy activity to show all inputs types and widgets",
+    "preamble": "This activity will show you all the different input type and widgets currently available.",
     "schemaVersion": "1.0.0-rc1",
     "version": "0.0.1",
     "ui": {
@@ -99,6 +100,18 @@
                 {"isAbout": "items/audio_check_item",
                 "variableName": "audio_check_item",
                 "isVis": true
+                },
+                {"isAbout": "items/audio_passage_record_item",
+                "variableName": "audio_passage_record_item",
+                "isVis": true
+                },
+                {"isAbout": "items/button_start_item",
+                "variableName": "button_start_item",
+                "isVis": true
+                },
+                {"isAbout": "items/audio_image_record_item",
+                "variableName": "audio_image_record_item",
+                "isVis": true
                 }
         ],
         "order": [
@@ -120,12 +133,14 @@
             "items/sign_item",
             "items/document_upload_item",
             "items/save_item",
-            "items/read_only_item",
-            "items/static_item",
+            "items/button_start_item",
             "items/audio_check_item",
+            "items/audio_passage_record_item",
+            "items/audio_image_record_item",
+            "items/static_item",
             "items/float_item",
-            "items/slider_item"
-            
+            "items/slider_item",
+            "items/read_only_item"
         ],
         "shuffle": false,
         "allow": [

--- a/activities/AllWidgetsDemo/items/audio_auto_record_item
+++ b/activities/AllWidgetsDemo/items/audio_auto_record_item
@@ -1,0 +1,18 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc1/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "audio_auto_record_item",
+    "prefLabel": "audio auto record item",
+    "description": "This is an audio auto record item.",
+    "schemaVersion": "1.0.0-rc1",
+    "version": "0.0.1",
+    "question": "Going to test your microphone. Click on the start button and then say something audibly.",
+    "ui": {
+        "inputType": "audioAutoRecord"
+    },
+    "responseOptions": {
+        "valueType": "schema:AudioObject",
+        "minValue": 0,
+        "maxValue": 60000
+    }
+}

--- a/activities/AllWidgetsDemo/items/audio_check_item
+++ b/activities/AllWidgetsDemo/items/audio_check_item
@@ -1,0 +1,18 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc1/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "audio_check_item",
+    "prefLabel": "audio check item",
+    "description": "This is a audio check item.",
+    "schemaVersion": "1.0.0-rc1",
+    "version": "0.0.1",
+    "question": "This is an audio check item. Click on the start button and say something audibly. Click Play button to hear your recording. If you think there is too much background noise, please go somewhere quieter and Redo, else click Continue.",
+    "ui": {
+        "inputType": "audioCheck"
+    },
+    "responseOptions": {
+        "valueType": "schema:AudioObject",
+        "minValue": 0,
+        "maxValue": 4000
+    }
+}

--- a/activities/AllWidgetsDemo/items/audio_image_record_item
+++ b/activities/AllWidgetsDemo/items/audio_image_record_item
@@ -1,0 +1,20 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc1/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "audio_image_record_item",
+    "prefLabel": "audio image record item",
+    "description": "This is a audio image record item.",
+    "schemaVersion": "1.0.0-rc1",
+    "version": "0.0.1",
+    "image": "https://picsum.photos/500/400",
+    "question": "This is an audio image record item where the particpant describe verbally an image shown below for a minute",
+    "ui": {
+        "inputType": "audioImageRecord"
+    },
+    "responseOptions": {
+        "valueType": "schema:AudioObject",
+        "minValue": 0,
+        "maxValue": 60000,
+        "multipleChoice": false
+    }
+}

--- a/activities/AllWidgetsDemo/items/audio_number_record_item
+++ b/activities/AllWidgetsDemo/items/audio_number_record_item
@@ -1,0 +1,18 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc1/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "audio_number_record_item",
+    "prefLabel": "audio numbers record item",
+    "description": "This is a audio number record item.",
+    "schemaVersion": "1.0.0-rc1",
+    "version": "0.0.1",
+    "question": "This will record while the participant as he or she says these numbers out loud.",
+    "ui": {
+        "inputType": "audioRecordNumberTask"
+    },
+    "responseOptions": {
+        "valueType": "schema:AudioObject",
+        "minValue": 0,
+        "maxValue": 60000
+    }
+}

--- a/activities/AllWidgetsDemo/items/audio_passage_record_item
+++ b/activities/AllWidgetsDemo/items/audio_passage_record_item
@@ -1,0 +1,18 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc1/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "audio_passage_record_item",
+    "prefLabel": "audio passage record item",
+    "description": "This is a audio passage record item.",
+    "schemaVersion": "1.0.0-rc1",
+    "version": "0.0.1",
+    "question": "This will record while the participant reads a passage from a story.",
+    "ui": {
+        "inputType": "audioPassageRecord"
+    },
+    "responseOptions": {
+        "valueType": "schema:AudioObject",
+        "minValue": 0,
+        "maxValue": 60000
+    }
+}

--- a/activities/AllWidgetsDemo/items/button_start_item
+++ b/activities/AllWidgetsDemo/items/button_start_item
@@ -1,0 +1,18 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc1/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "button_start_item",
+    "prefLabel": "button start item",
+    "description": "This is a button start item.",
+    "schemaVersion": "1.0.0-rc1",
+    "version": "0.0.1",
+    "question": "Please record your voice to test your microphone. Click on the start button and then say something.",
+    "ui": {
+        "inputType": "buttonStart"
+    },
+    "responseOptions": {
+        "valueType": "xsd:boolean",
+        "minValue": 0,
+        "maxValue": 1
+    }
+}

--- a/activities/AllWidgetsDemo/items/country_item
+++ b/activities/AllWidgetsDemo/items/country_item
@@ -1,0 +1,18 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc1/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "country_item",
+    "prefLabel": "country item",
+    "description": "This is a country item.",
+    "schemaVersion": "1.0.0-rc1",
+    "version": "0.0.1",
+    "question": "This is an item where the user can select a country.",
+    "ui": {
+        "inputType": "selectCountry"
+    },
+    "responseOptions": {
+        "valueType": "xsd:string",
+        "maxLength": 50,
+        "choices": "https://raw.githubusercontent.com/samayo/country-json/master/src/country-by-name.json"
+    }
+}

--- a/activities/AllWidgetsDemo/items/date_item
+++ b/activities/AllWidgetsDemo/items/date_item
@@ -1,0 +1,16 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc1/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "date_item",
+    "prefLabel": "date item",
+    "description": "This is a date item.",
+    "schemaVersion": "1.0.0-rc1",
+    "version": "0.0.1",
+    "question": "This is an item where the user can input a date.",
+    "ui": {
+        "inputType": "date"
+    },
+    "responseOptions": {
+        "valueType": "xsd:date"
+    }
+}

--- a/activities/AllWidgetsDemo/items/document_upload_item
+++ b/activities/AllWidgetsDemo/items/document_upload_item
@@ -1,0 +1,16 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc1/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "document_upload_item",
+    "prefLabel": "document upload item",
+    "description": "This is a document upload item.",
+    "schemaVersion": "1.0.0-rc1",
+    "version": "0.0.1",
+    "question": "This is an item where the user can upload a document.",
+    "ui": {
+        "inputType": "documentUpload"
+    },
+    "responseOptions": {
+        "valueType": "DigitalDocument"
+    }
+}

--- a/activities/AllWidgetsDemo/items/email_item
+++ b/activities/AllWidgetsDemo/items/email_item
@@ -1,0 +1,16 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc1/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "email_item",
+    "prefLabel": "email item",
+    "description": "This is an email item.",
+    "schemaVersion": "1.0.0-rc1",
+    "version": "0.0.1",
+    "question": "This is an item where the user can input an email address.",
+    "ui": {
+        "inputType": "email"
+    },
+    "responseOptions": {
+        "valueType": "xsd:string"
+    }
+}

--- a/activities/AllWidgetsDemo/items/float_item
+++ b/activities/AllWidgetsDemo/items/float_item
@@ -1,0 +1,16 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc1/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "float_item",
+    "prefLabel": "float item",
+    "description": "This is a float item.",
+    "schemaVersion": "1.0.0-rc1",
+    "version": "0.0.1",
+    "question": "This is an item where the user can input a float like 3.1415926...",
+    "ui": {
+        "inputType": "float"
+    },
+    "responseOptions": {
+        "valueType": "xsd:float"
+    }
+}

--- a/activities/AllWidgetsDemo/items/integer_item
+++ b/activities/AllWidgetsDemo/items/integer_item
@@ -1,0 +1,16 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc1/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "integer_item",
+    "prefLabel": "integer item",
+    "description": "This is a integer item.",
+    "schemaVersion": "1.0.0-rc1",
+    "version": "0.0.1",
+    "question": "This is an item where the user can input a integer like 3, -4 or 321...",
+    "ui": {
+        "inputType": "number"
+    },
+    "responseOptions": {
+        "valueType": "xsd:integer"
+    }
+}

--- a/activities/AllWidgetsDemo/items/language_item
+++ b/activities/AllWidgetsDemo/items/language_item
@@ -1,0 +1,18 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc1/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "language_item",
+    "prefLabel": "language item",
+    "description": "This is a language item.",
+    "schemaVersion": "1.0.0-rc1",
+    "version": "0.0.1",
+    "question": "This is an item where the user can select several language.",
+    "ui": {
+        "inputType": "selectLanguage"
+    },
+    "responseOptions": {
+        "valueType": "xsd:string",
+        "multipleChoice": true,
+        "choices": "https://raw.githubusercontent.com/ReproNim/reproschema-library/master/resources/languages.json"
+    }
+}

--- a/activities/AllWidgetsDemo/items/multitext_item
+++ b/activities/AllWidgetsDemo/items/multitext_item
@@ -1,0 +1,17 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc1/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "multitext_item",
+    "prefLabel": "multitext item",
+    "description": "This is a multitext item.",
+    "schemaVersion": "1.0.0-rc1",
+    "version": "0.0.1",
+    "question": "This is an item where the user can input several text field.",
+    "ui": {
+        "inputType": "multitext"
+    },
+    "responseOptions": {
+        "valueType": "xsd:string",
+        "maxLength": 300
+    }
+}

--- a/activities/AllWidgetsDemo/items/participant_id_item
+++ b/activities/AllWidgetsDemo/items/participant_id_item
@@ -1,0 +1,16 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc1/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "participant_id_item",
+    "prefLabel": "participant id item",
+    "description": "This is a participant id item.",
+    "schemaVersion": "1.0.0-rc1",
+    "version": "0.0.1",
+    "question": "This is an item where the user can input the participant id number.",
+    "ui": {
+        "inputType": "pid"
+    },
+    "responseOptions": {
+        "valueType": "xsd:string"
+    }
+}

--- a/activities/AllWidgetsDemo/items/radio_item
+++ b/activities/AllWidgetsDemo/items/radio_item
@@ -1,0 +1,33 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc1/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "radio_item",
+    "prefLabel": "radio item",
+    "description": "This is a radio item.",
+    "schemaVersion": "1.0.0-rc1",
+    "version": "0.0.1",
+    "question": "This is an example of a radio item with several possible answers to choose from (only one answer allowed).",
+    "ui": {
+        "inputType": "radio"
+    },
+    "responseOptions": {
+        "valueType": "xsd:integer",
+        "minValue": 0,
+        "maxValue": 2,
+        "multipleChoice": false,
+        "choices": [
+            {
+                "name": "Response option 1",
+                "value": 0
+            },
+            {
+                "name": "Response option 2",
+                "value": 1
+            },
+            {
+                "name": "Response option 3",
+                "value": 2
+            }
+        ]
+    }
+}

--- a/activities/AllWidgetsDemo/items/radio_item_multiple_choice
+++ b/activities/AllWidgetsDemo/items/radio_item_multiple_choice
@@ -1,0 +1,33 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc1/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "radio_item_multiple_choice",
+    "prefLabel": "radio item with multiple choice",
+    "description": "This is a radio item with multiple choice.",
+    "schemaVersion": "1.0.0-rc1",
+    "version": "0.0.1",
+    "question": "This is an example of a radio item with several possible answers to choose from (several answers allowed).",
+    "ui": {
+        "inputType": "radio"
+    },
+    "responseOptions": {
+        "valueType": "xsd:integer",
+        "minValue": 0,
+        "maxValue": 2,
+        "multipleChoice": true,
+        "choices": [
+            {
+                "name": "Response option 1",
+                "value": 0
+            },
+            {
+                "name": "Response option 2",
+                "value": 1
+            },
+            {
+                "name": "Response option 3",
+                "value": 2
+            }
+        ]
+    }
+}

--- a/activities/AllWidgetsDemo/items/read_only_item
+++ b/activities/AllWidgetsDemo/items/read_only_item
@@ -1,0 +1,19 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc1/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "read_only_item",
+    "prefLabel": "read only item",
+    "description": "This is a read only item.",
+    "schemaVersion": "1.0.0-rc1",
+    "version": "0.0.1",
+    "question": "This is read only item with an integer value.",
+    "ui": {
+        "inputType": "xsd:int",
+        "readonlyValue": true
+    },
+    "responseOptions": {
+        "valueType": "xsd:integer",
+        "minValue": 0,
+        "maxValue": 5
+    }
+}

--- a/activities/AllWidgetsDemo/items/save_item
+++ b/activities/AllWidgetsDemo/items/save_item
@@ -1,0 +1,14 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc1/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "save_item",
+    "prefLabel": "save item",
+    "description": "This is a item to save data to server.",
+    "schemaVersion": "1.0.0-rc1",
+    "version": "0.0.1",
+    "question": "This is a save item.",
+    "ui": {
+        "inputType": "save",
+        "readonlyValue": true
+    }
+}

--- a/activities/AllWidgetsDemo/items/select_item
+++ b/activities/AllWidgetsDemo/items/select_item
@@ -1,0 +1,33 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc1/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "select_item",
+    "prefLabel": "select item",
+    "description": "This is a select item that works with a drop down menu.",
+    "schemaVersion": "1.0.0-rc1",
+    "version": "0.0.1",
+    "question": "This is an example of a select item with several possible answers to choose from a dropdown menu (only one answer allowed).",
+    "ui": {
+        "inputType": "select"
+    },
+    "responseOptions": {
+        "valueType": "xsd:integer",
+        "minValue": 0,
+        "maxValue": 2,
+        "multipleChoice": false,
+        "choices": [
+            {
+                "name": "Response option 1",
+                "value": 0
+            },
+            {
+                "name": "Response option 2",
+                "value": 1
+            },
+            {
+                "name": "Response option 3",
+                "value": 2
+            }
+        ]
+    }
+}

--- a/activities/AllWidgetsDemo/items/select_item_multiple_choice
+++ b/activities/AllWidgetsDemo/items/select_item_multiple_choice
@@ -1,0 +1,33 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc1/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "select_item_multiple_choice",
+    "prefLabel": "select item multiple choice",
+    "description": "This is a select item that works with a drop down menu.",
+    "schemaVersion": "1.0.0-rc1",
+    "version": "0.0.1",
+    "question": "This is an example of a select item with several possible answers to choose from a dropdown menu (several answers allowed).",
+    "ui": {
+        "inputType": "select"
+    },
+    "responseOptions": {
+        "valueType": "xsd:integer",
+        "minValue": 0,
+        "maxValue": 2,
+        "multipleChoice": true,
+        "choices": [
+            {
+                "name": "Response option 1",
+                "value": 0
+            },
+            {
+                "name": "Response option 2",
+                "value": 1
+            },
+            {
+                "name": "Response option 3",
+                "value": 2
+            }
+        ]
+    }
+}

--- a/activities/AllWidgetsDemo/items/sign_item
+++ b/activities/AllWidgetsDemo/items/sign_item
@@ -1,0 +1,16 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc1/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "sign_item",
+    "prefLabel": "sign item",
+    "description": "This is a sign item.",
+    "schemaVersion": "1.0.0-rc1",
+    "version": "0.0.1",
+    "question": "This is an item where the user can sign.",
+    "ui": {
+        "inputType": "sign"
+    },
+    "responseOptions": {
+        "valueType": "xsd:string"
+    }
+}

--- a/activities/AllWidgetsDemo/items/slider_item
+++ b/activities/AllWidgetsDemo/items/slider_item
@@ -1,0 +1,43 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc1/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "slider_item",
+    "prefLabel": "slider item",
+    "description": "This is a slider item.",
+    "schemaVersion": "1.0.0-rc1",
+    "version": "0.0.1",
+    "question": "This is an example of a slider item.",
+    "ui": {
+        "inputType": "slider"
+    },
+    "responseOptions": {
+        "valueType": "xsd:integer",
+        "minValue": 0,
+        "maxValue": 4,
+        "multipleChoice": false,
+        "choices": [
+            {
+                "name": "Response option 1",
+                "value": 0
+            },
+            {
+                "name": "Response option 2",
+                "value": 1
+            },
+            {
+                "name": "Response option 3",
+                "value": 2
+            },
+            {
+                "name": "Response option 4",
+                "value": 3
+            }
+            ,
+            {
+                "name": "Response option 5",
+                "value": 4
+            }
+
+        ]
+    }
+}

--- a/activities/AllWidgetsDemo/items/state_item
+++ b/activities/AllWidgetsDemo/items/state_item
@@ -1,0 +1,17 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc1/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "state_item",
+    "prefLabel": "state item",
+    "description": "This is a state item.",
+    "schemaVersion": "1.0.0-rc1",
+    "version": "0.0.1",
+    "question": "This is an item where the user can select a USA state.",
+    "ui": {
+        "inputType": "selectState"
+    },
+    "responseOptions": {
+        "valueType": "xsd:string",
+        "choices": "https://gist.githubusercontent.com/mshafrir/2646763/raw/8b0dbb93521f5d6889502305335104218454c2bf/states_hash.json"
+    }
+}

--- a/activities/AllWidgetsDemo/items/static_item
+++ b/activities/AllWidgetsDemo/items/static_item
@@ -1,0 +1,19 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc1/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "static_item",
+    "prefLabel": "static item",
+    "description": "This is a static item.",
+    "schemaVersion": "1.0.0-rc1",
+    "version": "0.0.1",
+    "question": "This is a save item.",
+    "ui": {
+        "inputType": "static",
+        "readonlyValue": true
+    },
+    "responseOptions": {
+        "valueType": "xsd:boolean",
+        "minValue": 0,
+        "maxValue": 1
+    }
+}

--- a/activities/AllWidgetsDemo/items/text_item
+++ b/activities/AllWidgetsDemo/items/text_item
@@ -1,0 +1,17 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc1/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "text_item",
+    "prefLabel": "text item",
+    "description": "This is a text item.",
+    "schemaVersion": "1.0.0-rc1",
+    "version": "0.0.1",
+    "question": "This is an item where the user can input some text wiht a max length of 300.",
+    "ui": {
+        "inputType": "text"
+    },
+    "responseOptions": {
+        "valueType": "xsd:string",
+        "maxLength": 300
+    }
+}

--- a/activities/AllWidgetsDemo/items/time_range_item
+++ b/activities/AllWidgetsDemo/items/time_range_item
@@ -1,0 +1,16 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc1/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "time_range_item",
+    "prefLabel": "time range item",
+    "description": "This is a time range item.",
+    "schemaVersion": "1.0.0-rc1",
+    "version": "0.0.1",
+    "question": "This is an item where the user can input a time range.",
+    "ui": {
+        "inputType": "timeRange"
+    },
+    "responseOptions": {
+        "valueType": "xsd:datetime"
+    }
+}

--- a/activities/AllWidgetsDemo/items/year_item
+++ b/activities/AllWidgetsDemo/items/year_item
@@ -1,0 +1,16 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc1/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "year_item",
+    "prefLabel": "year item",
+    "description": "This is a year item.",
+    "schemaVersion": "1.0.0-rc1",
+    "version": "0.0.1",
+    "question": "This is an item where the user can input a year.",
+    "ui": {
+        "inputType": "year"
+    },
+    "responseOptions": {
+        "valueType": "xsd:date"
+    }
+}


### PR DESCRIPTION
Related to #4 

This is a bit of "brute force" approach to "testing" but this activity could help show an example of each UI widget and make sure that they display properly.

To view the activity:
https://www.repronim.org/reproschema-ui/#/activities/0?url=https://raw.githubusercontent.com/Remi-Gau/demo-protocol/remi-activity_all_widgets/activities/AllWidgetsDemo/all_widgets_schema

included items:
- [x] radio_item
- [x] radio_item_multiple_choice
- [x] select_item
- [x] select_item_multiple_choice
- [x] slider_item
- [x] integer_item
- [x] time_range_item
- [x] text_item
- [x] email_item
- [x] multitext_item
- [x] language_item
- [x] date_item
- [x] float_item
- [x] participant_id_item
- [x] documentUpload: `DocumentUpload/DocumentUpload.vue`
- [x] save: `SaveData/SaveData.vue`
- [x] static: `Static/Static.vue`
- [ ] StaticReadOnly: `Static/Static.vue`
- [x] selectState: `SelectInput/SelectInput.vue`
- [x] selectCountry: `SelectInput/SelectInput.vue`
- [x] year: `YearInput/YearInput.vue`
- [x] audioCheck: `AudioCheck/AudioCheck.vue`
- [x] audioRecord: `WebAudioRecord/Audio.vue`
- [x] audioPassageRecord: `WebAudioRecord/Audio.vue`
- [x] audioImageRecord: `WebAudioRecord/Audio.vue`
- [x] audioRecordNumberTask: `WebAudioRecord/Audio.vue`
- [x] sign: `src/components/StudySign.StudySign.vue`


