### PR TITLE
automatically fetching the latest checksum

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -2,8 +2,6 @@
 
 name: CI
 
-env:
-  CHECKSUM:  8c5ca141a109ed3075b65c1da2691648e7fc8b16
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
 on:
@@ -26,7 +24,16 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: '12.x'
+    # Install jq if it's not already available
+    - name: Install jq
+      run: sudo apt-get install jq
 
+    # Fetch the latest commit hash
+    - name: Get latest commit hash from reproschema-ui
+      run: |
+        LATEST_HASH=$(curl -s https://api.github.com/repos/ReproNim/reproschema-ui/commits/master | jq -r '.sha')
+        echo "CHECKSUM=$LATEST_HASH" >> $GITHUB_ENV
+    
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
as mentioned here https://github.com/ReproNim/reproschema-demo/pull/1
old checksum can't display some UIs properly (e.g., `"inputType": "textarea"`), so I set up automatic fetching of the latest checksum in GA. it worked well on reproschema-demo
https://github.com/ReproNim/demo-protocol/blob/efe3ff2747b1bd32c60ca17eb0ea013c8357ca75/.github/workflows/build_deploy.yml#L31-L35
also, I want to rename the default branch from `master` to `main` because `main` is the default one for all new GitHub repo, so in our demo document, we don't have to add another line to tell them to change `master` to `main` when cloning our repo. If no one disagrees, I'll change it